### PR TITLE
chore: fix small typo in readme and update env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Template base to start new odoo vsf projects using vsf SDK
 
 ```sh
 2. yarn install
-3. copy apps/web/.env_example to apps/web/.env
+3. copy apps/web/.env.example to apps/web/.env
 4. yarn dev
 5. You can access with http://localhost:3000
 ```

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,4 @@
-ODOO_BASE_URL=https://vsfdemo15.labs.odoogap.com/
+NUXT_PUBLIC_ODOO_BASE_URL=https://vsfdemo15.labs.odoogap.com/
 
 NUXT_PUBLIC_MIDDLEWARE_URL=http://localhost:3000/
 NUXT_PUBLIC_MIDDLEWARE_PORT=8443


### PR DESCRIPTION
Fix a small typo in file name in README and fix Example Env variable.