### PR TITLE
fix: 🐛 nuxt storage url env example changing to redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ NUXT_PUBLIC_VSF_PORT=3000
 ## Storage envs
 # https://unstorage.unjs.io/drivers -> driver list options
 NUXT_STORAGE_DRIVER=redis
-NUXT_STORAGE_URL=redis://localhost:6379
+NUXT_STORAGE_URL=redis://redis:6379
 NUXT_STORAGE_INVALIDATION_KEY=123
 
 # Third party dependencies


### PR DESCRIPTION
changing redis env