### PR TITLE
fix: 🐛 #19034 public user at checkout contact information

### DIFF
--- a/domains/checkout/components/CheckoutContactInformation.vue
+++ b/domains/checkout/components/CheckoutContactInformation.vue
@@ -24,7 +24,7 @@ const props = defineProps({
  * @TODO extract this form behaviour, undo, commit, validate, etc. to a separate form composable
  */
 const { isOpen, open, close } = useDisclosure();
-const { email, name, isPublic } = toRefs(props.partnerData);
+const { email, name } = toRefs(props.partnerData);
 const { commit: commitEmail, undo: undoEmail } = useManualRefHistory(email);
 const { commit: commitName, undo: undoName } = useManualRefHistory(name);
 

--- a/domains/checkout/components/CheckoutContactInformation.vue
+++ b/domains/checkout/components/CheckoutContactInformation.vue
@@ -28,7 +28,7 @@ const { email, name, isPublic } = toRefs(props.partnerData);
 const { commit: commitEmail, undo: undoEmail } = useManualRefHistory(email);
 const { commit: commitName, undo: undoName } = useManualRefHistory(name);
 
-if (isPublic) {
+if (props.partnerData.isPublic && props.partnerData.id === 4) {
   name.value = "";
 }
 
@@ -41,6 +41,7 @@ const handleUpdatePartnerData = async () => {
     subscribeNewsletter: subscribeNewsletter.value,
   };
   await updatePartner(data);
+
   commitEmail();
   commitName();
   close();
@@ -67,7 +68,10 @@ const handleCancel = () => {
         {{ partnerData.id ? $t("contactInfo.edit") : $t("contactInfo.add") }}
       </SfButton>
     </div>
-    <div v-if="partnerData?.email" class="mt-2 md:w-[520px]">
+    <div
+      v-if="partnerData?.name && partnerData?.email"
+      class="mt-2 md:w-[520px]"
+    >
       <p>{{ name }}</p>
       <p>{{ email }}</p>
     </div>


### PR DESCRIPTION
✅ Closes: #19034

When is public user, checkout contact information is hiding now the anonymous user name "public user" and only displays when user has been created sucessfully