### PR TITLE
fix: 🐛 populate head on category pages just if category exists

### DIFF
--- a/domains/category/pages/category/[id].vue
+++ b/domains/category/pages/category/[id].vue
@@ -62,7 +62,11 @@ const pagination = computed(() => ({
 }));
 
 await loadCategory({ slug: String(route.fullPath) });
-useHead(categoryHead(category.value, String(route.fullPath)));
+
+if (category.value) {
+  useHead(categoryHead(category.value, String(route.fullPath)));
+}
+
 setMaxVisiblePages(isWideScreen.value);
 </script>
 <template>


### PR DESCRIPTION
.