### PR TITLE
fix: 🐛 category id page was loading a category without id param

### DIFF
--- a/domains/category/pages/category/[id].vue
+++ b/domains/category/pages/category/[id].vue
@@ -61,7 +61,14 @@ const pagination = computed(() => ({
   pageOptions: [5, 12, 15, 20],
 }));
 
-await loadCategory({ slug: String(route.fullPath) });
+const params = route.params as { id?: string | number; slug?: string };
+
+if (params.id) {
+  await loadCategory({
+    id: Number(params.id),
+    slug: String(route.fullPath),
+  });
+}
 
 if (category.value) {
   useHead(categoryHead(category.value, String(route.fullPath)));


### PR DESCRIPTION
loadQuery was responding an error because it just was receiving the slug as parameter. it should receive category id either. it was easiest to see when we filtered a product list inside category page